### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLWorkshop"
 uuid = "6821e370-b0bb-497c-beb7-809790cbeb12"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"


### PR DESCRIPTION
Automated patch version bump (1.0.0 -> 1.0.1) to release unreleased commits on `main` via JuliaRegistrator.