### PR TITLE
Fix the package test target

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,12 @@ version = "1.0.1"
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]
+
 [compat]
 Documenter = "1"
 julia = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,4 @@ using SciMLWorkshop
 using Test
 
 # Tests are just for docs generation
+@test nameof(SciMLWorkshop) === :SciMLWorkshop


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

- register the `Test` standard library in the package's `[extras]` and test target
- add a minimal package-load assertion to the existing test entrypoint

## Why

The Tests workflow currently stops before running an assertion because `test/runtests.jl` imports `Test`, but `Project.toml` does not declare it as a test dependency. `Pkg.test()` therefore fails with `ArgumentError: Package Test not found in current path`.

The missing target dates to the initial test/package metadata in `edcf346`; `de565661` exposed the current error after fixing the package import, and `97f50cc` made it persistent base CI by adding the Tests workflow.

## Local checks

- exact Julia 1.12.6 CI `Pkg.test` invocation: passed
- plain Julia 1.12.6 `Pkg.test()`: passed
- clean-worktree Julia 1.10.11 `Pkg.test()`: passed
- Runic `--check --diff .`: passed
- `git diff --check`: passed

Please ignore this draft until it has been reviewed by @ChrisRackauckas.