### PR TITLE
Declare Test as the test target

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,3 +9,9 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 [compat]
 Documenter = "1"
 julia = "1.10"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- declare the standard-library `Test` dependency in `[extras]`
- select it through `[targets].test`

## Root cause

The downgrade workflow reached `test/runtests.jl`, which imports `Test`, but the package project did not declare a test target. This reproduces on unmodified `main`; it is not a dependency-floor regression.

Declaring the existing test-only dependency lets `Pkg.test` construct the standard isolated test environment without adding a runtime dependency.

## Local verification

Using a fresh depot and Julia 1.10.11, I replayed the deployed downgrade sequence:

- `julia-downgrade-compat` v2.6.1 in `deps` mode resolved the minimum graph, including the new test target
- `Pkg.build()` completed
- `Pkg.test(; force_latest_compatible_version=false, allow_reresolve=false)` completed with `SciMLWorkshop tests passed`

Additional checks:

- Runic 1.7.0: 4/4 Julia files passed
- `actionlint .github/workflows/Downgrade.yml`: passed
- project TOML parsing: passed
- `git diff --check`: passed
