### PR TITLE
Update ensemble documentation for EnsembleContext

### DIFF
--- a/docs/src/solutions/gsa_henon_heiles.md
+++ b/docs/src/solutions/gsa_henon_heiles.md
@@ -76,9 +76,8 @@ end
 
 z0 = generate_ics(0.125, 10)
 
-function prob_func(prob,i,repeat)
-  @. prob.u0 = z0[i]
-  prob
+function prob_func(prob, context)
+  remake(prob; u0 = z0[context.sim_id])
 end
 
 ensprob = EnsembleProblem(prob, prob_func=prob_func)


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until reviewed by @ChrisRackauckas.

Depends on #66, which restores the declaring-package import used earlier on this
documentation page.

Sibling independent API follow-ons: #68 and #69.

## Change

Update the Hénon–Heiles ensemble `prob_func` to accept the current
`EnsembleContext`, select the trajectory with `context.sim_id`, and return a
remade problem instead of mutating `prob.u0`.

## Root cause

I reproduced the documented three-argument callback failure from a clean
`6a3cc6c` checkout with Julia 1.11.9, DifferentialEquations 8.0.2, and SciMLBase
3.36.0. A runtime-probe bisect identified SciMLBase
`5b0c68e54b4dcbdfa79bde742228424ee8d8d98d` (`Replace numargs-based prob_func
detection with EnsembleContext`) as the first failing dependency commit; its
parent `9b2fdcea12c385391eab8f7e3ac444402bc97dbc` passes the legacy probe.

## Local verification

- exact current-environment ensemble solve:
  `ENSEMBLE_CALLBACK_OK trajectories=2`
- Runic 1.7.0: all four Julia files passed `--check --verbose`
- `git diff upstream/main...HEAD --check`
- full executable docs on Julia 1.11.9, with #66 commit
  `a8b9dabe1d957cf4050ca138ab4f6b9b92b59964` and all three independent API
  follow-ons applied: passed (exit 0 in 2h13m)

The one- and two-hour integration-docs attempts both completed every executable
example, then exhausted their shell budgets inside Documenter's allocation-heavy
`HTMLWriter.dataslug` hashing. I preserved both traces and reran the unchanged
build with a six-hour Bash timeout, matching the repository's 4h9m historical
HTML rendering phase.

This branch contains one documentation commit based directly on current `main`.
It does not duplicate #66 or the two sibling API follow-ons, so the monolithic
hosted Documentation check can continue to report those unrelated pages until
all four small PRs land.
