### PR TITLE
Update PDE preconditioner for LinearSolve

### DIFF
--- a/docs/src/solutions/performance_pde.md
+++ b/docs/src/solutions/performance_pde.md
@@ -164,18 +164,15 @@ nothing #hide
 ## Part 6: Utilizing Preconditioned-GMRES Linear Solvers
 
 We use `KrylovJL_GMRES` with an incomplete LU factorization as a preconditioner.
-The `precs` callback receives the matrix `W = I - gamma*J` and returns preconditioners.
+The `precs` callback receives the linear operator and problem parameters and returns
+left and right preconditioners.
 
 ```@example performance_pde
 import IncompleteLU, LinearSolve
 
-function incompletelu(W, du, u, p, t, newW, Plprev, Prprev, solverdata)
-    if newW === nothing || newW
-        Pl = IncompleteLU.ilu(convert(AbstractMatrix, W), τ = 50.0)
-    else
-        Pl = Plprev
-    end
-    Pl, nothing
+function incompletelu(A, p)
+    Pl = IncompleteLU.ilu(convert(AbstractMatrix, A), τ = 50.0)
+    Pl, I
 end
 
 # Required for IncompleteLU to work with LinearSolve
@@ -183,7 +180,7 @@ Base.eltype(::IncompleteLU.ILUFactorization{Tv, Ti}) where {Tv, Ti} = Tv
 
 # Using sparse Jacobian with GMRES and ILU preconditioner
 sol6 = solve(prob3,
-    KenCarp47(linsolve = LinearSolve.KrylovJL_GMRES(), precs = incompletelu,
+    KenCarp47(linsolve = LinearSolve.KrylovJL_GMRES(precs = incompletelu),
         concrete_jac = true); save_everystep = false)
 # Benchmarking: @btime solve(prob3, KenCarp47(...); save_everystep = false);
 nothing #hide


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until reviewed by @ChrisRackauckas.

Depends on #66, which restores the declaring-package imports used earlier on
this documentation page.

Sibling independent API follow-ons: #67 and #68.

## Change

Move the ILU `precs` callback from `KenCarp47` to
`LinearSolve.KrylovJL_GMRES`, and update the example to LinearSolve's current
two-argument callback contract `(A, p) -> (Pl, Pr)`.

## Root cause

I reproduced the rejected `KenCarp47(..., precs=...)` keyword from a clean
`6a3cc6c` checkout with Julia 1.11.9, OrdinaryDiffEqSDIRK 2.8.1, and LinearSolve
4.3.0. A runtime-probe bisect identified OrdinaryDiffEq
`f359db295c251ee4db8df0e2e46047731f1b8345` (`refactor Linsolve to match
LinearSolve precs interface`) as the first failing dependency commit; its parent
`f73ee0c114bd7d3f32b660f4df0a90209c85675d` passes the legacy probe.

## Local verification

- exact current-environment solve exercising the callback:
  `PRECONDITIONER_API_OK retcode=Success`
- Runic 1.7.0: all four Julia files passed `--check --verbose`
- `git diff upstream/main...HEAD --check`
- full executable docs on Julia 1.11.9, with #66 commit
  `a8b9dabe1d957cf4050ca138ab4f6b9b92b59964` and all three independent API
  follow-ons applied: passed (exit 0 in 2h13m)

The one- and two-hour integration-docs attempts both completed every executable
example, then exhausted their shell budgets inside Documenter's allocation-heavy
`HTMLWriter.dataslug` hashing. I preserved both traces and reran the unchanged
build with a six-hour Bash timeout, matching the repository's 4h9m historical
HTML rendering phase.

This branch contains one documentation commit based directly on current `main`.
It does not duplicate #66 or the two sibling API follow-ons, so the monolithic
hosted Documentation check can continue to report those unrelated pages until
all four small PRs land.
