### PR TITLE
Remove duplicate test target tables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,9 +15,3 @@ test = ["Test"]
 [compat]
 Documenter = "1"
 julia = "1.10"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]


### PR DESCRIPTION
## Summary

Remove the duplicate `[extras]` and `[targets]` tables appended by #65.

## Root cause

`1d5dcb5` appended a second copy of the test target that was already present from #64. Julia therefore rejects `Project.toml` with `key already defined` at the second `[extras]` table before package loading or testing can begin.

## Validation

- Julia 1.10.11: `Pkg.test(; coverage = true)` — passed
- Runic check on all tracked Julia files — passed
- `git diff --check` — passed

Please ignore this PR until reviewed by @ChrisRackauckas.
