### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLWorkshop"
 uuid = "6821e370-b0bb-497c-beb7-809790cbeb12"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `SciMLWorkshop` | 1.0.1 | 1.0.2 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).