### PR TITLE
Declare SciMLTesting >= 2.4 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,5 +15,5 @@ test = ["Test"]
 
 [compat]
 Documenter = "1"
-SciMLTesting = "2.10"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.0.2"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
@@ -14,4 +15,5 @@ test = ["Test"]
 
 [compat]
 Documenter = "1"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -15,5 +15,5 @@ test = ["Test"]
 
 [compat]
 Documenter = "1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -3,17 +3,14 @@ uuid = "6821e370-b0bb-497c-beb7-809790cbeb12"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 version = "1.0.2"
 
-[deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-
 [extras]
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["SciMLTesting", "Test"]
 
 [compat]
-Documenter = "1"
 SciMLTesting = "2.4"
+Test = "1"
 julia = "1.10"

--- a/docs/src/solutions/gsa_henon_heiles.md
+++ b/docs/src/solutions/gsa_henon_heiles.md
@@ -4,7 +4,7 @@
 
 ```@example henon
 using DifferentialEquations, Plots, DiffEqPhysics
-using OrdinaryDiffEqRKN: DPRKN6
+using OrdinaryDiffEqRKN: DPRKN6, FineRKN4
 
 function henon(dz,z,p,t)
   p₁, p₂, q₁, q₂ = z[1], z[2], z[3], z[4]
@@ -28,7 +28,6 @@ plot(sol, idxs=[(3,4,1)], tspan=(0,100))
 
 ```@example henon
 function henon(ddz,dz,z,p,t)
-  p₁, p₂ = dz[1], dz[2]
   q₁, q₂ = z[1], z[2]
   ddq₁ = -q₁*(1 + 2q₂)
   ddq₂ = -q₂-(q₁^2 - q₂^2)
@@ -47,7 +46,7 @@ plot(sol, vars=[(3,4)], tspan=(0,100))
 H(p, q, params) = 1/2 * (p[1]^2 + p[2]^2) + 1/2 * (q[1]^2 + q[2]^2 + 2q[1]^2 * q[2] - 2/3*q[2]^3)
 
 prob3 = HamiltonianProblem(H, p₀, q₀, (0., 1000.))
-sol = solve(prob3, DPRKN6(), abstol=1e-10, reltol=1e-10)
+sol = solve(prob3, FineRKN4(), abstol=1e-10, reltol=1e-10)
 
 plot(sol, idxs=[(3,4)], tspan=(0,100))
 ```

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SciMLWorkshop = "6821e370-b0bb-497c-beb7-809790cbeb12"
+
+[compat]
+SafeTestsets = "0.1, 1"
+SciMLTesting = "2.4"
+SciMLWorkshop = "1"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,4 @@
+using SciMLTesting
+using SciMLWorkshop
+
+run_qa(SciMLWorkshop)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,12 @@
+using SciMLTesting
 using SciMLWorkshop
 using Test
 
-# Tests are just for docs generation
-@test nameof(SciMLWorkshop) === :SciMLWorkshop
+run_tests(
+    ;
+    core = () -> @test(nameof(SciMLWorkshop) === :SciMLWorkshop),
+    qa = (;
+        env = joinpath(@__DIR__, "qa"),
+        body = joinpath(@__DIR__, "qa", "qa.jl"),
+    ),
+)


### PR DESCRIPTION
## What changed

This PR now wires the repository through the standard SciMLTesting test harness rather than only declaring a compat entry:

- adds `SciMLTesting = "2.4"` to the package compatibility bounds and test target;
- routes the core and QA groups through `run_tests`;
- adds an isolated `test/qa` environment whose body calls `run_qa(SciMLWorkshop)`;
- removes the stale `Documenter` runtime dependency from the package (Documenter remains in `docs/Project.toml`);
- fixes two executable documentation examples: the second-order Henon-Heiles example no longer reads an unsupported velocity sentinel, and the Hamiltonian example uses `FineRKN4`, which supports the generated velocity-dependent form.

No package API behavior was changed, and no repository-specific public-documentation QA override was added.

## Verification

- `env GROUP=QA timeout 3600 julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`
  - passed: `QA | 20 20`
- standalone Hamiltonian algorithm check
  - `DPRKN6` reproduces the velocity-dependence error;
  - `FineRKN4` passes and integrates the example.
- `typos Project.toml test/runtests.jl docs/src/solutions/gsa_henon_heiles.md test/qa/qa.jl test/qa/Project.toml`
  - passed
- `git diff --check`
  - passed
- the docs build reached example expansion, cross-reference/document checks, and HTML rendering without another example failure; the one-hour local run timed out during HTML rendering. It did not complete successfully.
- the local `runic` executable is the workspace-agent CLI rather than the Julia formatter, so formatter verification is left to CI.

Please ignore this draft until reviewed by @ChrisRackauckas.